### PR TITLE
Use string for a file mode, not fixnum

### DIFF
--- a/manifests/basics.pp
+++ b/manifests/basics.pp
@@ -4,6 +4,6 @@
 class subversion::basics {
   file{'/srv/svn':
     ensure => directory,
-    owner => root, group => 0, mode => 0755;
+    owner => root, group => 0, mode => '0755';
   }
 }


### PR DESCRIPTION
For compatibility with puppet 4.0. As specified in recent puppet documentation [0], using numeric literals for file modes is a deprecated feature. With puppet 4.1 (tested on Fedora 22) the configuration of /srv/svn fails with the following message:

Error: Parameter mode failed on File[/srv/svn]: The file mode specification must be a string, not 'Fixnum' at /etc/puppet/modules/subversion/manifests/basics.pp:5

I believe switching to using a string in that resource should be backwards compatible, although I haven't tested myself.

[0] https://docs.puppetlabs.com/puppet/3.7/reference/deprecated_resource.html#non-string-mode-values
